### PR TITLE
Setting limit for gradlew workers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,14 +116,8 @@ workflows:
   commit:
     jobs:
       - generate_swagger:
-          name: generate swagger api << matrix.gate_api_branch >>
-          matrix:
-            parameters:
-              gate_api_branch: [ "release-1.19.x", "release-1.18.x", "release-1.17.x" ]
+          name: generate swagger api
       - build:
-          name: build against gate << matrix.gate_api_branch >>
-          matrix:
-            parameters:
-              gate_api_branch: [ "release-1.19.x", "release-1.18.x", "release-1.17.x" ]
+          name: build
           requires:
-            - generate swagger api << matrix.gate_api_branch >>
+            - generate swagger api

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,9 @@ jobs:
           name: Generate swagger.json
           command: |
             cd /floodgate/gate
-            ./swagger/generate_swagger.sh
-            cp ./swagger/swagger.json ./gate-swagger.json
+            ./gradlew clean
+            ./gradlew gate-web:test --tests *GenerateSwagger* --max-workers 2
+            cat gate-web/swagger.json | json_pp > ./gate-swagger.json
       - run:
           name: Generate gateapi go code
           command: java -jar /floodgate/bin/swagger-codegen-cli.jar generate -l go -i /floodgate/gate/gate-swagger.json -o /floodgate/gateapi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,14 @@ workflows:
   commit:
     jobs:
       - generate_swagger:
-          name: generate swagger api
+          name: generate swagger api << matrix.gate_api_branch >>
+          matrix:
+            parameters:
+              gate_api_branch: [ "release-1.19.x", "release-1.18.x", "release-1.17.x" ]
       - build:
-          name: build
+          name: build against gate << matrix.gate_api_branch >>
+          matrix:
+            parameters:
+              gate_api_branch: [ "release-1.19.x", "release-1.18.x", "release-1.17.x" ]
           requires:
-            - generate swagger api
+            - generate swagger api << matrix.gate_api_branch >>


### PR DESCRIPTION
During build gradlew uses much more resources that is is allowed. When host on which gradlew is running is utilized more, CircleCI is killing processes which are using to much resources. 
Because of that we need to limit gradlew manually. 

Closes #17 