### PR TITLE
Check if the user is logged in before working with Spinnaker

### DIFF
--- a/resourcemanager/resourcemanager.go
+++ b/resourcemanager/resourcemanager.go
@@ -36,11 +36,11 @@ func (rm *ResourceManager) Init(config *c.Config, customOptions ...Option) error
 		}
 	}
 	rm.client = gc.NewGateapiClient(config)
-	user, resp, err := rm.client.AuthControllerApi.LoggedOutUsingGET(rm.client.Context)
+	user, _, err := rm.client.AuthControllerApi.LoggedOutUsingGET(rm.client.Context)
 	if err != nil {
 		return err
 	}
-	if user == nil {
+	if user == "" {
 		return fmt.Errorf("authenticating with Spinnaker failed. check if credentials are valid")
 	}
 	parser, err := p.NewParser(options.fileLoaders...)

--- a/resourcemanager/resourcemanager.go
+++ b/resourcemanager/resourcemanager.go
@@ -22,7 +22,7 @@ type ResourceManager struct {
 	client    *gc.GateapiClient
 }
 
-// Init initialize sync
+// Init initializes ResourceManager
 func (rm *ResourceManager) Init(config *c.Config, customOptions ...Option) error {
 	options := Options{}
 	for _, option := range customOptions {
@@ -36,6 +36,13 @@ func (rm *ResourceManager) Init(config *c.Config, customOptions ...Option) error
 		}
 	}
 	rm.client = gc.NewGateapiClient(config)
+	user, resp, err := rm.client.AuthControllerApi.LoggedOutUsingGET(rm.client.Context)
+	if err != nil {
+		return err
+	}
+	if user == nil {
+		return fmt.Errorf("authenticating with Spinnaker failed. check if credentials are valid")
+	}
 	parser, err := p.NewParser(options.fileLoaders...)
 	if err != nil {
 		return err

--- a/spinnakerresource/application.go
+++ b/spinnakerresource/application.go
@@ -104,6 +104,9 @@ func (a Application) SaveLocalState(spinnakerAPI *gateclient.GateapiClient) erro
 		"description": "Creating application",
 	}
 	task, _, err := spinnakerAPI.TaskControllerApi.TaskUsingPOST1(spinnakerAPI.Context, createApplicationTask)
+	if task == nil {
+		return fmt.Errorf("failed to save application, status code: %d", resp.StatusCode)
+	}
 	if err != nil {
 		return err
 	}

--- a/spinnakerresource/application.go
+++ b/spinnakerresource/application.go
@@ -103,7 +103,7 @@ func (a Application) SaveLocalState(spinnakerAPI *gateclient.GateapiClient) erro
 		"application": a.name,
 		"description": "Creating application",
 	}
-	task, _, err := spinnakerAPI.TaskControllerApi.TaskUsingPOST1(spinnakerAPI.Context, createApplicationTask)
+	task, resp, err := spinnakerAPI.TaskControllerApi.TaskUsingPOST1(spinnakerAPI.Context, createApplicationTask)
 	if task == nil {
 		return fmt.Errorf("failed to save application, status code: %d", resp.StatusCode)
 	}


### PR DESCRIPTION
As in the title. This allows to not waste time by working on empty data returned by Spinnaker, if no authentication is obtained.