### PR TITLE
Switch to latest ubuntu image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
         type: string
         default: ""
     machine:
-      image: circleci/ubuntu-1604:202004-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,6 +212,9 @@ workflows:
       - generate_swagger:
           &filters-release
           filters:
+            branches:
+              ignore:
+                - /.*/
             tags:
               only:
                 - /v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -212,9 +212,6 @@ workflows:
       - generate_swagger:
           &filters-release
           filters:
-            branches:
-              ignore:
-                - /.*/
             tags:
               only:
                 - /v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
         type: string
         default: ""
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/ubuntu-1604:202004-01
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This PR is going to switch to latest Ubuntu image available in CircleCI: Ubuntu 16.04 from 2020.04
 Waiting time for packages update is reduced significantly: https://app.circleci.com/pipelines/github/codilime/floodgate/305/workflows/2323115c-dc53-4850-a4ff-c38398d093ff