### PR TITLE
Improvements to release process

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ jobs:
           command: |
             if [ -z "$CIRCLE_BRANCH" ]
             then
-                export RELEASE=$(echo $CIRLE_TAG | sed 's/^v[0-9]\+\.[0-9]\+\.[0-9]\+-\?//')
+                export RELEASE=$(echo $CIRCLE_TAG | sed 's/^v[0-9]\+\.[0-9]\+\.[0-9]\+-\?//')
             else
                 export RELEASE=$CIRCLE_BRANCH
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,8 +213,8 @@ workflows:
           &filters-release
           filters:
             branches:
-              ignore:
-                - /.*/
+              only:
+                - /release-v[0-9]+\.[0-9]+\.x/
             tags:
               only:
                 - /v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,12 @@ jobs:
           command: go test -v ./...
       - run:
           name: Compile code
-          command: go build
+          command: |
+            go build -ldflags "-X github.com/codilime/floodgate/version.GitCommit=$(git rev-parse HEAD) \
+            -X github.com/codilime/floodgate/version.BuiltDate=$(date  +%Y-%m-%d_%H:%M:%S) \
+            -X github.com/codilime/floodgate/version.GoVersion=$(go version | sed 's/go version //g') \
+            -X github.com/codilime/floodgate/version.GateVersion=<< parameters.gate_api_branch >> \
+            "
       - run:
           name: Check linting
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,9 +104,16 @@ jobs:
       - run:
           name: Compile code
           command: |
+            if [ $(git tag --contains | egrep "^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$") -gt 0 ]
+            then
+                export RELEASE=$(git tag --contains | egrep "^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$" | head -n 1 | sed 's/^v[0-9]\+\.[0-9]\+\.[0-9]\+//')
+            else
+                export RELEASE=$(git branch | grep '*' | awk '{ print $2 }')
+            fi
             env
             go build -ldflags "-X github.com/codilime/floodgate/version.GitCommit=$CIRCLE_SHA1 \
             -X github.com/codilime/floodgate/version.BuiltDate=$(date  +%Y-%m-%d_%H:%M:%S) \
+            -X github.com/codilime/floodgate/version.Release=$RELEASE \
             -X github.com/codilime/floodgate/version.GoVersion=$GOLANG_VERSION \
             -X github.com/codilime/floodgate/version.GateVersion=$(echo '<< parameters.gate_api_branch >>' | sed 's/release-//' \
             "

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,7 +107,7 @@ jobs:
             go build -ldflags "-X github.com/codilime/floodgate/version.GitCommit=$CIRCLE_SHA1 \
             -X github.com/codilime/floodgate/version.BuiltDate=$(date  +%Y-%m-%d_%H:%M:%S) \
             -X github.com/codilime/floodgate/version.GoVersion=$GOLANG_VERSION \
-            -X github.com/codilime/floodgate/version.GateVersion='<< parameters.gate_api_branch >>' \
+            -X github.com/codilime/floodgate/version.GateVersion=$(echo '<< parameters.gate_api_branch >>' | sed 's/release-//' \
             "
       - run:
           name: Check linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,11 +114,11 @@ jobs:
       - run:
           name: Compile code
           command: |
-            if [ $(git tag --contains | egrep "^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$") -gt 0 ]
+            if [ -z "$CIRCLE_BRANCH" ]
             then
-                export RELEASE=$(git tag --contains | egrep "^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$" | head -n 1 | sed 's/^v[0-9]\+\.[0-9]\+\.[0-9]\+-\?//')
+                export RELEASE=$(echo $CIRLE_TAG | sed 's/^v[0-9]\+\.[0-9]\+\.[0-9]\+-\?//')
             else
-                export RELEASE=$(git branch | grep '*' | awk '{ print $2 }')
+                export RELEASE=$CIRCLE_BRANCH
             fi
             env
             go build -ldflags "-X github.com/codilime/floodgate/version.GitCommit=$CIRCLE_SHA1 \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ jobs:
             -X github.com/codilime/floodgate/version.BuiltDate=$(date  +%Y-%m-%d_%H:%M:%S) \
             -X github.com/codilime/floodgate/version.Release=$RELEASE \
             -X github.com/codilime/floodgate/version.GoVersion=$GOLANG_VERSION \
-            -X github.com/codilime/floodgate/version.GateVersion=$(echo '<< parameters.gate_api_branch >>' | sed 's/release-//' \
+            -X github.com/codilime/floodgate/version.GateVersion=$(echo '<< parameters.gate_api_branch >>' | sed 's/release-//') \
             "
       - run:
           name: Check linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,10 +104,10 @@ jobs:
       - run:
           name: Compile code
           command: |
-            go build -ldflags "-X github.com/codilime/floodgate/version.GitCommit=$(git rev-parse HEAD) \
+            go build -ldflags "-X github.com/codilime/floodgate/version.GitCommit=$CIRCLE_SHA1 \
             -X github.com/codilime/floodgate/version.BuiltDate=$(date  +%Y-%m-%d_%H:%M:%S) \
-            -X github.com/codilime/floodgate/version.GoVersion=$(go version | sed 's/go version //g') \
-            -X github.com/codilime/floodgate/version.GateVersion=<< parameters.gate_api_branch >> \
+            -X github.com/codilime/floodgate/version.GoVersion=$GOLANG_VERSION \
+            -X github.com/codilime/floodgate/version.GateVersion='<< parameters.gate_api_branch >>' \
             "
       - run:
           name: Check linting

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ jobs:
         type: string
         default: ""
     machine:
-      image: circleci/classic:201808-01
+      image: ubuntu-1604:202004-01
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ aliases:
   release-filters: &filters-release
     filters:
       branches:
-        ignore:
+        only:
           - /release-v[0-9]+\.[0-9]+\.x/
       tags:
         only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,12 @@ jobs:
             sudo mkdir -p /floodgate/bin
             sudo chmod 777 /floodgate/bin
             cp /go/src/github.com/codilime/floodgate/floodgate /floodgate/bin/floodgate
+      - run:
+          name: Generate checksum
+          command: |
+            cd /go/src/github.com/codilime/floodgate/
+            cp floodgate floodgate-<< parameters.gate_api_branch >>
+            sha1sum floodgate-<< parameters.gate_api_branch >> > floodgate-<< parameters.gate_api_branch >>.sha1sum
       - persist_to_workspace:
           root: /floodgate/bin
           paths:
@@ -147,6 +153,9 @@ jobs:
       - store_artifacts:
           path: /go/src/github.com/codilime/floodgate/floodgate
           destination: floodgate-<< parameters.gate_api_branch >>
+      - store_artifacts:
+          path: /go/src/github.com/codilime/floodgate/floodgate-<< parameters.gate_api_branch >>.sha1sum
+          destination: floodgate-<< parameters.gate_api_branch >>.sha1sum
 
   start_spinnaker:
     parameters: 
@@ -194,6 +203,7 @@ jobs:
           name: Test Floodgate against running Spinnaker instance
           command: |
             /floodgate/bin/floodgate --version
+            /floodgate/bin/floodgate version
             /floodgate/bin/floodgate << parameters.floodgate_extra_params >> --config ~/floodgate.yaml compare && exit 1 || echo "Found changes"
             /floodgate/bin/floodgate << parameters.floodgate_extra_params >> --config ~/floodgate.yaml sync
             /floodgate/bin/floodgate << parameters.floodgate_extra_params >> --config ~/floodgate.yaml compare

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -106,7 +106,7 @@ jobs:
           command: |
             if [ $(git tag --contains | egrep "^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$") -gt 0 ]
             then
-                export RELEASE=$(git tag --contains | egrep "^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$" | head -n 1 | sed 's/^v[0-9]\+\.[0-9]\+\.[0-9]\+//')
+                export RELEASE=$(git tag --contains | egrep "^v[0-9]+\.[0-9]+\.[0-9]+(-rc[0-9]+)?$" | head -n 1 | sed 's/^v[0-9]\+\.[0-9]\+\.[0-9]\+-\?//')
             else
                 export RELEASE=$(git branch | grep '*' | awk '{ print $2 }')
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,6 +104,7 @@ jobs:
       - run:
           name: Compile code
           command: |
+            env
             go build -ldflags "-X github.com/codilime/floodgate/version.GitCommit=$CIRCLE_SHA1 \
             -X github.com/codilime/floodgate/version.BuiltDate=$(date  +%Y-%m-%d_%H:%M:%S) \
             -X github.com/codilime/floodgate/version.GoVersion=$GOLANG_VERSION \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,7 +28,7 @@ func NewRootCmd(out io.Writer) *cobra.Command {
 	cmd := &cobra.Command{
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		Version:       version.String(),
+		Version:       version.Short(),
 	}
 	cmd.PersistentFlags().StringVar(&options.configFile, "config", "", "path to config file (default $HOME/.config/floodgate/config.yaml)")
 	cmd.PersistentFlags().BoolVarP(&options.quiet, "quiet", "q", false, "hide non-essential output")
@@ -53,6 +53,7 @@ func NewRootCmd(out io.Writer) *cobra.Command {
 	cmd.AddCommand(NewHydrateCmd(out))
 	cmd.AddCommand(NewInspectCmd(out))
 	cmd.AddCommand(NewRenderCmd(out))
+	cmd.AddCommand(NewVersionCmd(out))
 
 	return cmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,32 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/codilime/floodgate/version"
+	"github.com/spf13/cobra"
+)
+
+// renderOptions store render command options
+type versionOptions struct {
+}
+
+// NewVersionCmd create new render command
+func NewVersionCmd(out io.Writer) *cobra.Command {
+	options := renderOptions{}
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print info about version",
+		Long:  "Prints information about version and build details",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runVersion(cmd, options)
+		},
+	}
+	return cmd
+}
+
+func runVersion(cmd *cobra.Command, options renderOptions) error {
+	fmt.Printf(version.BuildInfo())
+	return nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -2,25 +2,58 @@ package version
 
 import "fmt"
 
+// GitCommit string
+var GitCommit string
+
+// Release string
+var Release string
+
+// GateVersion string
+var GateVersion string
+
+// BuiltDate string
+var BuiltDate string
+
+// GoVersion string
+var GoVersion string
+
 type version struct {
-	major   int
-	minor   int
-	path    int
-	release string
+	major int
+	minor int
+	patch int
 }
 
-func (v version) String() string {
-	return fmt.Sprintf("%d.%d.%d-%s", v.major, v.minor, v.path, v.release)
+func (v version) BuildInfo() string {
+	gateAPIInfo := "\nGate API version:\t" + GateVersion
+	goInfo := "\nGo version:\t" + GoVersion
+	gitCommitInfo := "\nGit commit:\t" + GitCommit
+	builtDateInfo := "\nBuilt:\t" + BuiltDate
+
+	return "Version:\t" + v.Short() + gateAPIInfo + goInfo + gitCommitInfo + builtDateInfo
+
+}
+
+func (v version) Short() string {
+	versionInfo := fmt.Sprintf("%d.%d.%d", v.major, v.minor, v.patch)
+	if Release != "" {
+		versionInfo = versionInfo + "-" + Release
+	}
+
+	return versionInfo
 }
 
 var floodgateVersion = version{
-	major:   0,
-	minor:   1,
-	path:    0,
-	release: "dev",
+	major: 0,
+	minor: 1,
+	patch: 0,
 }
 
-// String get Floodgate version string
-func String() string {
-	return floodgateVersion.String()
+// Short get Floodgate version string
+func Short() string {
+	return floodgateVersion.Short()
+}
+
+// BuildInfo get Floodgate build info
+func BuildInfo() string {
+	return floodgateVersion.BuildInfo()
 }

--- a/version/version.go
+++ b/version/version.go
@@ -25,11 +25,11 @@ type version struct {
 
 func (v version) BuildInfo() string {
 	gateAPIInfo := "\nGate API version:\t" + GateVersion
-	goInfo := "\nGo version:\t" + GoVersion
-	gitCommitInfo := "\nGit commit:\t" + GitCommit
-	builtDateInfo := "\nBuilt:\t" + BuiltDate + "\n"
+	goInfo := "\nGo version:\t\t" + GoVersion
+	gitCommitInfo := "\nGit commit:\t\t" + GitCommit
+	builtDateInfo := "\nBuilt:\t\t\t" + BuiltDate + "\n"
 
-	return "Version:\t" + v.Short() + gateAPIInfo + goInfo + gitCommitInfo + builtDateInfo
+	return "Version:\t\t" + v.Short() + gateAPIInfo + goInfo + gitCommitInfo + builtDateInfo
 
 }
 

--- a/version/version.go
+++ b/version/version.go
@@ -27,7 +27,7 @@ func (v version) BuildInfo() string {
 	gateAPIInfo := "\nGate API version:\t" + GateVersion
 	goInfo := "\nGo version:\t" + GoVersion
 	gitCommitInfo := "\nGit commit:\t" + GitCommit
-	builtDateInfo := "\nBuilt:\t" + BuiltDate
+	builtDateInfo := "\nBuilt:\t" + BuiltDate + "\n"
 
 	return "Version:\t" + v.Short() + gateAPIInfo + goInfo + gitCommitInfo + builtDateInfo
 


### PR DESCRIPTION
Some improvements to release pipeline and extended version info
* execute release pipeline on tags and branches (with `release` prefix)
* add checksum calculation after proper compilation
* add version command with extended info about version and compilation parameters

Closes #72 