### PR TITLE
Fix readme's typo eg. to e.g.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ## Motivation
 
-This project integrates multiple parts of "as-code" experience in Spinnaker, eg. API, Sponnet, Pipeline Templates for a complete GitOps workflow. 
+This project integrates multiple parts of "as-code" experience in Spinnaker, e.g. API, Sponnet, Pipeline Templates for a complete GitOps workflow. 
 
 ## Features
 


### PR DESCRIPTION
## What

As title.

## Why

It comes from the Latin “exempli gratia”, so I would have thought it correct to place a period after the e and after the g in place of the missing letters.