### PR TITLE
Fix typo resources' to resource's

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,10 +105,10 @@ Usage:
    [command]
 
 Available Commands:
-  compare     Compare local resources' definitions with Spinnaker and show discrepancies
+  compare     Compare local resource's definitions with Spinnaker and show discrepancies
   help        Help about any command
   hydrate     Hydrate pipeline templates with configurations and preview the result
-  inspect     Inspect resources' status on Spinnaker
+  inspect     Inspect resource's status on Spinnaker
   render      Render Jsonnet files
   synchronize Synchronize resources to Spinnaker
 

--- a/cmd/compare.go
+++ b/cmd/compare.go
@@ -19,8 +19,8 @@ func NewCompareCmd(out io.Writer) *cobra.Command {
 	options := compareOptions{}
 	cmd := &cobra.Command{
 		Use:   "compare",
-		Short: "Compare local resources' definitions with Spinnaker and show discrepancies",
-		Long:  "Compare local resources' definitions with Spinnaker and show discrepancies",
+		Short: "Compare local resource's definitions with Spinnaker and show discrepancies",
+		Long:  "Compare local resource's definitions with Spinnaker and show discrepancies",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCompare(cmd, options)
 		},

--- a/cmd/inspect.go
+++ b/cmd/inspect.go
@@ -18,8 +18,8 @@ func NewInspectCmd(out io.Writer) *cobra.Command {
 	options := inspectOptions{}
 	cmd := &cobra.Command{
 		Use:   "inspect",
-		Short: "Inspect resources' status on Spinnaker",
-		Long:  "Inspect resources' status on Spinnaker",
+		Short: "Inspect resource's status on Spinnaker",
+		Long:  "Inspect resource's status on Spinnaker",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runInspect(cmd, options)
 		},

--- a/resourcemanager/resourcemanager.go
+++ b/resourcemanager/resourcemanager.go
@@ -56,7 +56,7 @@ func (rm *ResourceManager) Init(config *c.Config, customOptions ...Option) error
 	return nil
 }
 
-// GetChanges get resources' changes
+// GetChanges get resource's changes
 func (rm ResourceManager) GetChanges() (changes []ResourceChange) {
 	for _, application := range rm.resources.Applications {
 		var change string


### PR DESCRIPTION
## What 

I fixed the typo `resources'` to `resource's`.

## Why

Better document 👍 