### PR TITLE
parametric timeout added

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,7 @@ var location string
 // Config is the default configuration for the app
 type Config struct {
 	Endpoint  string      `json:"endpoint"`
+	Timeout   int64       `json:"timeout"`
 	Insecure  bool        `json:"insecure"`
 	Auth      auth.Config `json:"auth"`
 	Libraries []string    `json:"libraries"`

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,4 +1,5 @@
 endpoint: https://127.0.0.1/api/v1
+timeout: 10
 insecure: true
 auth:
   basic:

--- a/gateclient/gateclient.go
+++ b/gateclient/gateclient.go
@@ -27,7 +27,7 @@ type GateapiClient struct {
 func NewGateapiClient(floodgateConfig *config.Config) *GateapiClient {
 	cookieJar, _ := cookiejar.New(nil)
 	var gateHTTPClient = &http.Client{
-		Timeout: 5 * time.Second,
+		Timeout: time.Duration(floodgateConfig.Timeout) * time.Second,
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: floodgateConfig.Insecure},
 		},


### PR DESCRIPTION
Is your feature request related to a problem? Please describe.
We need to increase 5 seconds timeout in Floodgate config so we need to convert it from static to parametrical. If you have too many applications and pipelines, default timeout duration may cause api errors.

Describe the solution you'd like
Add Timeout parameter in config struct
type Config struct { Endpoint string json:"endpoint"Timeout int64 json:"timeout"Insecure bool json:"insecure"Auth auth.Configjson:"auth"Libraries []string json:"libraries"Resources []string json:"resources" }

Change Timeout from static to parametric in http.Client
var gateHTTPClient = &http.Client{ Timeout: time.Duration(floodgateConfig.Timeout) * time.Second, Transport: &http.Transport{ TLSClientConfig: &tls.Config{InsecureSkipVerify: floodgateConfig.Insecure}, }, Jar: cookieJar, }

I want to make this change a new branch and create a pull request then.