### PR TITLE
if resource does not exists on remote, floodgate does not create it. …

### DIFF
--- a/spinnakerresource/application.go
+++ b/spinnakerresource/application.go
@@ -32,6 +32,7 @@ func (a *Application) Init(api *gc.GateapiClient, localData map[string]interface
 	a.name = name
 	if api != nil {
 		if err := a.LoadRemoteState(api); err != nil {
+			err := a.SaveLocalState(api)
 			return err
 		}
 	}

--- a/spinnakerresource/pipeline.go
+++ b/spinnakerresource/pipeline.go
@@ -41,6 +41,7 @@ func (p *Pipeline) Init(api *gc.GateapiClient, localData map[string]interface{})
 	p.templateReference = reference
 	if api != nil {
 		if err := p.LoadRemoteState(api); err != nil {
+			err := p.SaveLocalState(api)
 			return err
 		}
 	}

--- a/spinnakerresource/pipelinetemplate.go
+++ b/spinnakerresource/pipelinetemplate.go
@@ -35,6 +35,7 @@ func (pt *PipelineTemplate) Init(api *gc.GateapiClient, localData map[string]int
 	pt.name = name
 	if api != nil {
 		if err := pt.LoadRemoteState(api); err != nil {
+			err := pt.SaveLocalState(api)
 			return err
 		}
 	}


### PR DESCRIPTION
Describe the bug
When we synth our resources, Floodgate makes changes to our existing resources but it never creates our new resources. When we investigate, we should make change on spinnaker resource directory as like that:

if api != nil { if err := a.LoadRemoteState(api); err != nil { err := a.SaveLocalState(api) return err } }

If loadRemoteState has an error (does not exist error) local state should be saved on remote. This is quick solution. If you want to resolve this issue on me. I can do clean solution.